### PR TITLE
update dependency information for Gradle

### DIFF
--- a/src/site/markdown/dependency-info.md
+++ b/src/site/markdown/dependency-info.md
@@ -69,7 +69,7 @@ Browse the "Project Modules" index of streams-project to find artifacts you migh
 
 <div class="section">
 
-<h3><a name="Grails"></a>Grails</h3><a name="Grails"></a>
+<h3><a name="Gradle"></a>Gradle</h3><a name="Gradle"></a>
 
 <div class="source"><pre class="prettyprint">compile 'org.apache.streams:streams-master:0.3-incubating-SNAPSHOT'</pre>
 


### PR DESCRIPTION
I am pretty sure that "Gradle" is meant here. Grails does use Gradle, but grails is not, itself, a build tool.